### PR TITLE
fix：添加m4a音频格式字符串

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,6 +28,7 @@
         <item>aac</item>
         <item>flac</item>
         <item>ogg</item>
+        <item>m4a</item>
     </string-array>
     
     <string-array name="audio_quality_options">


### PR DESCRIPTION
1. 修复了m4a音频格式字符串缺失问题